### PR TITLE
Fixed typo that causes issues with artist images

### DIFF
--- a/src/library/wrapper.js
+++ b/src/library/wrapper.js
@@ -226,7 +226,7 @@ class Wrapper extends EventEmitter {
 
 					extra = 'Artist 👤'
 					images = artist.images
-``
+
 					break
 
 				case 'album':


### PR DESCRIPTION
Fixed typo that caused issues with artist images. 

Caused the following error:
TypeError: artist.images is not a function

Fixes #17