### PR TITLE
Fix volume button error and add configurable step size

### DIFF
--- a/com.ntanis.essentials-for-spotify.sdPlugin/manifest.json
+++ b/com.ntanis.essentials-for-spotify.sdPlugin/manifest.json
@@ -215,6 +215,7 @@
 			"UUID": "com.ntanis.essentials-for-spotify.volume-up-button",
 			"Icon": "images/actions/volume-up",
 			"Tooltip": "Increases the playback volume.",
+			"PropertyInspectorPath": "pi/volume-up-button.html",
 			"DisableAutomaticStates": true,
 			"Controllers": [
 				"Keypad"
@@ -231,6 +232,7 @@
 			"UUID": "com.ntanis.essentials-for-spotify.volume-down-button",
 			"Icon": "images/actions/volume-down",
 			"Tooltip": "Decreases the playback volume.",
+			"PropertyInspectorPath": "pi/volume-down-button.html",
 			"DisableAutomaticStates": true,
 			"Controllers": [
 				"Keypad"

--- a/src/actions/volume-down-button.ts
+++ b/src/actions/volume-down-button.ts
@@ -20,9 +20,18 @@ export default class VolumeDownButton extends Button {
 		if (wrapper.volumePercent === null)
 			return constants.WRAPPER_RESPONSE_NOT_AVAILABLE
 
-		if (wrapper.muted && wrapper.mutedVolumePercent > constants.VOLUME_STEP_SIZE)
+		if (wrapper.muted && wrapper.mutedVolumePercent > this.settings[context]?.step)
 			await wrapper.unmuteVolume()
 
-		return wrapper.setPlaybackVolume(wrapper.volumePercent - constants.VOLUME_STEP_SIZE)
+		return wrapper.setPlaybackVolume(wrapper.volumePercent - this.settings[context]?.step)
+	}
+
+	async onSettingsUpdated(context: string, oldSettings: any): Promise<void> {
+		await super.onSettingsUpdated(context, oldSettings)
+
+		if (!this.settings[context].step)
+			await this.setSettings(context, {
+				step: 5
+			})
 	}
 }

--- a/src/actions/volume-up-button.ts
+++ b/src/actions/volume-up-button.ts
@@ -20,6 +20,15 @@ export default class VolumeUpButton extends Button {
 		if (wrapper.volumePercent === null)
 			return constants.WRAPPER_RESPONSE_NOT_AVAILABLE
 
-		return wrapper.setPlaybackVolume((wrapper.muted ? wrapper.mutedVolumePercent : wrapper.volumePercent) + constants.VOLUME_STEP_SIZE)
+		return wrapper.setPlaybackVolume((wrapper.muted ? wrapper.mutedVolumePercent : wrapper.volumePercent) + this.settings[context]?.step)
+	}
+
+	async onSettingsUpdated(context: string, oldSettings: any): Promise<void> {
+		await super.onSettingsUpdated(context, oldSettings)
+
+		if (!this.settings[context].step)
+			await this.setSettings(context, {
+				step: 5
+			})
 	}
 }

--- a/src/ui/pi/volume-down-button.html
+++ b/src/ui/pi/volume-down-button.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head lang="en">
+    <meta charset="utf-8" />
+    <script src="sdpi-components.js"></script>
+</head>
+<body>
+    <sdpi-item label="Volume Step">
+        <sdpi-range
+            setting="step"
+            min="1"
+            max="10"
+            step="1"
+            showlabels>
+        </sdpi-range>
+    </sdpi-item>
+</body>
+</html>
+

--- a/src/ui/pi/volume-up-button.html
+++ b/src/ui/pi/volume-up-button.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head lang="en">
+    <meta charset="utf-8" />
+    <script src="sdpi-components.js"></script>
+</head>
+<body>
+    <sdpi-item label="Volume Step">
+        <sdpi-range
+            setting="step"
+            min="1"
+            max="10"
+            step="1"
+            showlabels>
+        </sdpi-range>
+    </sdpi-item>
+</body>
+</html>
+


### PR DESCRIPTION
## Problem

Commit 73c6723 (volume control step + some cleanup) introduced a breaking change where VOLUME_STEP_SIZE was removed from constants.js, but references to it remained in volume-up-button.ts and volume-down-button.ts. This caused:

- Volume buttons to send NaN to Spotify API
- API error: volume_percent must be a number
- Complete failure of volume up/down buttons

## Root Cause Analysis

In commit 73c6723, the volume control dial was refactored to use a configurable step size from user settings (this.settings[context]?.step) instead of a hardcoded constant. The constant was removed, but the volume up/down buttons continued referencing constants.VOLUME_STEP_SIZE, which evaluated to undefined.

When JavaScript evaluated wrapper.volumePercent + undefined, it resulted in NaN, which Spotify API rightfully rejected.

## Solution

Rather than simply restoring the constant, this PR implements the same configurable approach for volume buttons, providing consistency across all volume controls.

### Changes Made:

1. Created UI configuration files:
   - src/ui/pi/volume-up-button.html
   - src/ui/pi/volume-down-button.html
   - Both feature a slider (range 1-10) for configurable step size
   - Show min/max labels for clarity

2. Updated volume button TypeScript files:
   - Changed constants.VOLUME_STEP_SIZE to this.settings[context]?.step
   - Added onSettingsUpdated() method to initialize default step size of 5
   - Maintains backward compatibility

3. Updated manifest.json:
   - Added PropertyInspectorPath entries for both volume buttons
   - Links buttons to their respective configuration UIs

## Benefits

- Fixes broken volume controls - Buttons now work correctly
- Consistent UX - All volume controls (dial + buttons) now configurable
- User customization - Users can set different step sizes for different buttons
- Backward compatible - Defaults to step size of 5 (original constant value)
- Follows existing pattern - Matches volume-control-dial refactor approach

## Testing

- Volume up/down buttons work without API errors
- Settings UI displays Volume Step slider (1-10)
- Default step size is 5
- Step size is configurable and persists
- Volume changes by configured amount

## Related

- Fixes issue introduced by: 73c6723
- Follows pattern established in: 73c6723 (volume-control-dial refactor)