### PR TITLE
Add custom URL playlists support to My Playlists dial (Spotify-owned playlist workaround)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,14 @@ You are able to configure the behavior of some of them via their settings.
   - Push: Play
   - Touch: Play
   - Long Touch: Refresh  
+  - Extra Playlists (in action settings): Add one Spotify playlist URL per line to pin playlists that may not be returned by the Spotify API (for example some Spotify-owned playlists in Development Mode).
+
+  Example:
+  ```text
+  https://open.spotify.com/playlist/37i9dQZF1EQpoj8u9Hn81e?si=c592b10f6ada4223
+  https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M
+  https://open.spotify.com/playlist/37i9dQZF1DX0XUsuxWHRQd
+  ```
 - **New Releases**\
   Navigate and play through your personalized new releases.
   

--- a/com.ntanis.essentials-for-spotify.sdPlugin/manifest.json
+++ b/com.ntanis.essentials-for-spotify.sdPlugin/manifest.json
@@ -463,6 +463,7 @@
 			"UUID": "com.ntanis.essentials-for-spotify.my-playlists-dial",
 			"Icon": "images/actions/playlists",
 			"Tooltip": "Navigate and play through your playlists.",
+			"PropertyInspectorPath": "pi/my-playlists-dial.html",
 			"Controllers": [
 				"Encoder"
 			],

--- a/src/actions/items-dial.ts
+++ b/src/actions/items-dial.ts
@@ -22,7 +22,7 @@ export default class ItemsDial extends Dial {
 		if (this.#itemsPage[context] === undefined)
 			this.#itemsPage[context] = 1
 
-		const apiCall = await this.fetchItems(this.#itemsPage[context])
+		const apiCall = await this.fetchItems(this.#itemsPage[context], context)
 
 		if ((!apiCall) || typeof apiCall !== 'object' || (apiCall.status !== constants.WRAPPER_RESPONSE_SUCCESS && apiCall.status !== constants.WRAPPER_RESPONSE_SUCCESS_INDICATIVE)) {
 			this.resetFeedbackLayout(context, {
@@ -273,7 +273,7 @@ export default class ItemsDial extends Dial {
 		}, feedback))
 	}
 
-	async fetchItems(page: number): Promise<any> {
+	async fetchItems(page: number, context: string): Promise<any> {
         throw new Error('The fetchItems method must be implemented in a subclass.')
 	}
 

--- a/src/actions/my-playlists-dial.ts
+++ b/src/actions/my-playlists-dial.ts
@@ -1,18 +1,154 @@
 import {
 	action
 } from '@elgato/streamdeck'
+import {
+	fetch
+} from 'undici'
 
 import ItemsDial from './items-dial.js'
 
 import wrapper from './../library/wrapper.js'
 
+type CustomPlaylistItem = {
+	id: string
+	type: 'playlist'
+	name: string
+	images: Array<{ url: string }>
+}
+
 @action({ UUID: 'com.ntanis.essentials-for-spotify.my-playlists-dial' })
 export default class MyPlaylistsDial extends ItemsDial {
+	static readonly PLAYLIST_URL_REGEX = /^https?:\/\/open\.spotify\.com\/(?:intl-[a-z]{2}\/)?playlist\/([A-Za-z0-9]{22})(?:\/)?(?:\?.*)?$/i
+
+	#customItemsCache: {
+		[context: string]: Array<CustomPlaylistItem>
+	} = {}
+
+	#customItemsCacheKey: {
+		[context: string]: string
+	} = {}
+
 	constructor() {
 		super('layouts/items-layout.json', 'images/icons/playlists.png')
 	}
 
-	async fetchItems(page: number) {
-		return await wrapper.getPlaylists(page)
+	#getCustomPlaylistUrls(context: string): Array<string> {
+		const rawUrls = (this.settings[context]?.spotify_urls || '').toString()
+
+		if (!rawUrls.trim())
+			return []
+
+		const uniqueUrls = new Set<string>()
+
+		for (const entry of rawUrls.split(/\r?\n/)) {
+			const normalized = entry.trim()
+
+			if (!normalized)
+				continue
+
+			if (!MyPlaylistsDial.PLAYLIST_URL_REGEX.test(normalized))
+				continue
+
+			uniqueUrls.add(normalized)
+		}
+
+		return Array.from(uniqueUrls)
+	}
+
+	#extractPlaylistId(url: string): string | null {
+		const match = url.match(MyPlaylistsDial.PLAYLIST_URL_REGEX)
+		return match ? match[1] : null
+	}
+
+	async #resolveCustomPlaylist(url: string): Promise<CustomPlaylistItem | null> {
+		const id = this.#extractPlaylistId(url)
+
+		if (!id)
+			return null
+
+		// Public oEmbed metadata works even when Web API access is limited for Spotify-owned playlists.
+		try {
+			const response = await fetch(`https://open.spotify.com/oembed?url=${encodeURIComponent(url)}`)
+
+			if (response.ok) {
+				const data: any = await response.json()
+
+				return {
+					id,
+					type: 'playlist',
+					name: data?.title || `Playlist ${id.slice(0, 6)}`,
+					images: data?.thumbnail_url ? [{
+						url: data.thumbnail_url
+					}] : []
+				}
+			}
+		} catch { }
+
+		const detail = await wrapper.getInformationOnUrl(url)
+
+		if (detail?.type === 'playlist')
+			return {
+				id,
+				type: 'playlist',
+				name: (detail.title && !detail.title.startsWith('Unknown')) ? detail.title : `Playlist ${id.slice(0, 6)}`,
+				images: detail.images || []
+			}
+
+		return {
+			id,
+			type: 'playlist',
+			name: `Playlist ${id.slice(0, 6)}`,
+			images: []
+		}
+	}
+
+	async #getCustomPlaylistItems(context: string): Promise<Array<CustomPlaylistItem>> {
+		const urls = this.#getCustomPlaylistUrls(context)
+		const cacheKey = urls.join('\n')
+
+		if (this.#customItemsCacheKey[context] === cacheKey)
+			return this.#customItemsCache[context] || []
+
+		const details = await Promise.all(urls.map(url => this.#resolveCustomPlaylist(url)))
+		const items: Array<CustomPlaylistItem> = []
+		const seen = new Set<string>()
+
+		for (const detail of details) {
+			if (!detail || detail.type !== 'playlist' || !detail.id || seen.has(detail.id))
+				continue
+
+			seen.add(detail.id)
+
+			items.push({
+				id: detail.id,
+				type: 'playlist',
+				name: detail.name || 'Unknown Playlist',
+				images: detail.images || []
+			})
+		}
+
+		this.#customItemsCacheKey[context] = cacheKey
+		this.#customItemsCache[context] = items
+
+		return items
+	}
+
+	async fetchItems(page: number, context: string) {
+		const customItems = await this.#getCustomPlaylistItems(context)
+		return await wrapper.getPlaylists(page, customItems)
+	}
+
+	async onSettingsUpdated(context: string, oldSettings: any): Promise<void> {
+		await super.onSettingsUpdated(context, oldSettings)
+
+		if (typeof this.settings[context].spotify_urls !== 'string')
+			await this.setSettings(context, {
+				spotify_urls: ''
+			})
+
+		if ((oldSettings?.spotify_urls || '') !== (this.settings[context].spotify_urls || '')) {
+			delete this.#customItemsCacheKey[context]
+			delete this.#customItemsCache[context]
+		}
 	}
 }

--- a/src/actions/new-releases-dial.ts
+++ b/src/actions/new-releases-dial.ts
@@ -12,7 +12,7 @@ export default class NewReleasesDial extends ItemsDial {
 		super('layouts/items-layout.json', 'images/icons/items.png')
 	}
 
-	async fetchItems(page: number) {
+	async fetchItems(page: number, _context: string) {
 		return await wrapper.getNewReleases(page)
 	}
 }

--- a/src/library/constants.js
+++ b/src/library/constants.js
@@ -45,7 +45,8 @@ const CONNECTOR_DEFAULT_SCOPES = [
 	'user-read-private',
 	'user-library-read',
 	'user-library-modify',
-	'playlist-read-private'
+	'playlist-read-private',
+	'playlist-read-collaborative'
 ]
 
 const CHARACTER_WIDTH_MAP = {

--- a/src/ui/pi/my-playlists-dial.html
+++ b/src/ui/pi/my-playlists-dial.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<head lang="en">
+    <meta charset="utf-8" />
+    <script src="sdpi-components.js"></script>
+</head>
+<body>
+    <sdpi-item label="Extra Playlists">
+        <sdpi-textarea
+            setting="spotify_urls"
+            rows="6"
+            placeholder="One Spotify playlist URL per line&#10;https://open.spotify.com/playlist/...">
+        </sdpi-textarea>
+    </sdpi-item>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This PR adds support for custom playlist URLs in the **My Playlists** dial so users can pin playlists manually (including Spotify-owned/editorial playlists that may not be returned by `me/playlists` in development-mode apps).

## What changed

- Added a Property Inspector for **My Playlists** with a new `spotify_urls` setting (one URL per line)
- Added manifest wiring for `pi/my-playlists-dial.html`
- Implemented custom URL parsing/validation and metadata resolution in `MyPlaylistsDial`
- Added oEmbed metadata fallback to show proper playlist name/icon for Spotify-owned playlists
- Merged custom playlists with regular playlist results in wrapper pagination
- Added `playlist-read-collaborative` OAuth scope
- Updated README with usage and multi-URL example

## Example: add multiple playlists

In **My Playlists** action settings (`Extra Playlists`), add one URL per line, for example:

```text
https://open.spotify.com/playlist/37i9dQZF1EQpoj8u9Hn81e?si=c592b10f6ada4223
https://open.spotify.com/playlist/37i9dQZF1DXcBWIGoYBM5M
https://open.spotify.com/playlist/37i9dQZF1DX0XUsuxWHRQd
```

Then long-touch the dial to refresh.

## Validation

- Build passes: `npm run build`
- Manual behavior verified:
  - custom playlists appear in My Playlists
  - custom playlists show icon and resolved name
  - multiple URLs supported

---

**Disclosure:** this contribution was implemented with assistance from ChatGPT, then validated and cleaned for project consistency.